### PR TITLE
A few minor changes

### DIFF
--- a/api-commons-manifest.json
+++ b/api-commons-manifest.json
@@ -2,7 +2,7 @@
   "apis": [
     {
       "name": "Court Listener API",
-      "description": "U.S. court opinions API as part of the Court Listener project, which currently aggregates 2,204,339 court opinions, from 350 jurisdictions.",
+      "description": "U.S. court opinions API as part of the CourtListener project, which currently aggregates more than 2,204,339 court opinions, from over 350 jurisdictions.",
       "image": "https://2.gravatar.com/avatar/87d484ca9ada35fd56c0c097a3bd88c9?d=https%3A%2F%2Fidenticons.github.com%2F635ccb973201d401a01de2e96638acd7.png&r=x&s=440",
       "keywords": "legal,opinion,court,citations,US",
       "license": "http://creativecommons.org/licenses/by-sa/3.0/deed.en_US",
@@ -16,5 +16,5 @@
     }
   ],
   "tags": "api-commons-manifest",
-  "updated": "11/23/2013"
+  "updated": "11/24/2013"
 }

--- a/court-listener-api.json
+++ b/court-listener-api.json
@@ -62,7 +62,7 @@
             },
             {
               "name": "limit",
-              "description": "number of records to limi response listing by (1000 max)",
+              "description": "number of records to limit response listing by (1000 max)",
               "required": false,
               "allowMultiple": false,
               "dataType": "string",
@@ -207,7 +207,7 @@
             },
             {
               "name": "limit",
-              "description": "number of records to limi response listing by (1000 max)",
+              "description": "number of records to limit response listing by (1000 max)",
               "required": false,
               "allowMultiple": false,
               "dataType": "string",
@@ -352,8 +352,8 @@
       "operations": [
         {
           "method": "GET",
-          "summary": "Pulls opinions that opinion cites",
-          "notes": "Provides a paginated display of the opinions that an opinion cites",
+          "summary": "Pulls opinions that cite the opinion",
+          "notes": "Provides a paginated display of the opinions that cite the  opinion",
           "nickname": "getOpinion",
           "type": "opinion",
           "parameters": [
@@ -402,7 +402,7 @@
         {
           "method": "GET",
           "summary": "Pulls jurisdictions",
-          "notes": "Provides basic information about the 350 jurisdictions in the American court system",
+          "notes": "Provides basic information about the 350+ jurisdictions in the American court system",
           "nickname": "getJurisdiction",
           "type": "jurisdiction",
           "parameters": [
@@ -450,7 +450,7 @@
             },
             {
               "name": "limit",
-              "description": "number of records to limi response listing by (1000 max)",
+              "description": "number of records to limit response listing by (1000 max)",
               "required": false,
               "allowMultiple": false,
               "dataType": "string",
@@ -531,7 +531,7 @@
             },
             {
               "name": "limit",
-              "description": "number of records to limi response listing by (1000 max)",
+              "description": "number of records to limit response listing by (1000 max)",
               "required": false,
               "allowMultiple": false,
               "dataType": "string",
@@ -563,9 +563,9 @@
       "operations": [
         {
           "method": "GET",
-          "summary": "Runs advanced search",
-          "notes": "Provides an advanced search via solr",
-          "nickname": "search",
+          "summary": "Shows the number of opinions in each jurisdiction by year",
+          "notes": "Useful in identifying gaps in the corpus",
+          "nickname": "coverage",
           "type": "opinion",
           "parameters": [
             {
@@ -588,7 +588,7 @@
             },          
             {
               "name": "id",
-              "description": "Jurisdiction ID to be query",
+              "description": "Jurisdiction ID to be queried",
               "required": false,
               "allowMultiple": false,
               "dataType": "string",

--- a/court-listener-api.json
+++ b/court-listener-api.json
@@ -353,7 +353,7 @@
         {
           "method": "GET",
           "summary": "Pulls opinions that cite the opinion",
-          "notes": "Provides a paginated display of the opinions that cite the  opinion",
+          "notes": "Provides a paginated display of the opinions that cite the opinion",
           "nickname": "getOpinion",
           "type": "opinion",
           "parameters": [


### PR DESCRIPTION
Hi Kin,

I wanted you to review these because I'm not familiar with swagger, but they should amount to just typos and minor tweaks that sort of future-proof this, because we're always adding opinions and jurisdictions.

One thing I didn't change was that you dub this API version .1, but we're calling this API v1. I couldn't tell if the .1 referred to this definition or to our version-numbering system. If the latter, then I think that should be changed too.
